### PR TITLE
turn off @typescript-eslint/indent and rely exclusively on indent

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ module.exports = {
 		'one-var': off,
 		'require-atomic-updates': off,
 		'no-import-assign': warn,
-		'@typescript-eslint/indent': [ warn, 'tab' ],
+		'@typescript-eslint/indent': off,
 		'@typescript-eslint/camelcase': off,
 		'@typescript-eslint/no-use-before-define': off,
 		'@typescript-eslint/array-type': [ error, { default: 'array-simple' } ],


### PR DESCRIPTION
as requested in: https://github.com/sveltejs/svelte/pull/5031#discussion_r441260267

apparently @typescript-eslint/indent has 'myriad problems', so its probably more appropriate to rely solely on 'indent' rule.

more context: https://github.com/sveltejs/svelte/pull/5031#discussion_r441260919
related: https://github.com/typescript-eslint/typescript-eslint/issues/1824