### PR TITLE
Re-enable accidentally disabled linting of .svelte files

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,6 +72,13 @@ module.exports = {
 			rules: {
 				'@typescript-eslint/no-var-requires': off
 			}
+		},
+		{
+			files: ['*.svelte'],
+			processor: 'svelte3/svelte3',
+			rules: {
+				'@typescript-eslint/indent': off
+			}
 		}
 	]
 };

--- a/index.js
+++ b/index.js
@@ -75,10 +75,7 @@ module.exports = {
 		},
 		{
 			files: ['*.svelte'],
-			processor: 'svelte3/svelte3',
-			rules: {
-				'@typescript-eslint/indent': off
-			}
+			processor: 'svelte3/svelte3'
 		}
 	]
 };


### PR DESCRIPTION
I get non-sensical errors without this code block. Thanks to @Conduitry for the sharp eyes in noticing this shouldn't have been removed in https://github.com/sveltejs/eslint-config/pull/2