### PR TITLE
Add a rule to enforce single quotes

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ module.exports = {
 		'no-unreachable': 2,
 		'valid-typeof': 2,
 		'quote-props': [ 2, 'as-needed' ],
+		quotes: ['error', 'single'],
 		'prefer-arrow-callback': 2,
 		'prefer-const': [ 2, { destructuring: all } ],
 		'arrow-spacing': 2,


### PR DESCRIPTION
The codebase mostly uses single quotes today:

sveltejs:
5790 instances of single quotes
809 instances of double quotes

sapper:
839 instances of single quotes
30 instances double quotes