### PR TITLE
add rule eol-last: require newline at the end of files

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,6 +28,7 @@ module.exports = {
 		'one-var': off,
 		'require-atomic-updates': off,
 		'no-import-assign': warn,
+		'eol-last': error,
 		'@typescript-eslint/camelcase': off,
 		'@typescript-eslint/no-use-before-define': off,
 		'@typescript-eslint/array-type': [ error, { default: 'array-simple' } ],


### PR DESCRIPTION
**Reason for the rule**
mostly to make git happy

`git diff` shows warnings on missing newlines at end-of-file
in terms of function, this will (probably) have zero effect

**Examples**
with rule `eol-last`
* valid: `line 1\nline 2\nline 3\nline 4\n`
* error: `line 1\nline 2\nline 3\nline 4`

so much trouble for just one character ------------^

**Poll**
[![](https://api.gh-polls.com/poll/01EKFWQC2EF7WFQYXKRS5GCY3A/yes%2C%20lets%20add%20rule%20%60eol-last%60)](https://api.gh-polls.com/poll/01EKFWQC2EF7WFQYXKRS5GCY3A/yes%2C%20lets%20add%20rule%20%60eol-last%60/vote)
[![](https://api.gh-polls.com/poll/01EKFWQC2EF7WFQYXKRS5GCY3A/no%2C%20we%20dont%20need%20rule%20%60eol-last%60)](https://api.gh-polls.com/poll/01EKFWQC2EF7WFQYXKRS5GCY3A/no%2C%20we%20dont%20need%20rule%20%60eol-last%60/vote#but%20secretly%20all%20my%20text%20files%20end%20with%20newline)

**Background**
background is compatibility with POSIX tools
for example the 'word counter' `wc --lines input.js` 
prints the number of newline characters
since 'one line' in POSIX is defined as 'string + newline character'
and if the last line is not terminated with a `\n` 
then `wc -l` prints one line less (and the world ends)

**Exceptions**
one special case is: source code for svelte code examples
for aesthetic reasons, the code can be `trim()`med
to remove whitespace at end-of-file (as it is done now)
but there is no need to do this trimming in the file system
so the eslint-rule can apply to these files too

<details>
<summary>original post</summary>

.. to make `git diff` happy
.. for compatibility with POSIX tools
.. to reduce diff noise when appending to files

https://stackoverflow.com/questions/729692/why-should-text-files-end-with-a-newline

</details>