### PR TITLE
Allow either single quotes or template literals

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ module.exports = {
 		'no-unreachable': 2,
 		'valid-typeof': 2,
 		'quote-props': [ 2, 'as-needed' ],
-		quotes: ['error', 'single'],
+		quotes: ['error', 'single', { allowTemplateLiterals: true }],
 		'prefer-arrow-callback': 2,
 		'prefer-const': [ 2, { destructuring: all } ],
 		'arrow-spacing': 2,


### PR DESCRIPTION
Please vote with a thumbs up or thumbs down on whether you prefer this potential change

This PR allows strings to use either single quotes and template literals as the user chooses. This would allow the user to write strings in template literals without escaping single quotes such as `No custom element 'tag' option was specified`

The currently checked in code does not allow template literals unless they reference a variable, so strings with single quotes should be written either as `No custom element \'tag\' option was specified` or `No custom element "tag" option was specified`. It offers more firmness around users using single quotes for a string like `foobar` with no quotes or variables