### PR TITLE
Set avoidEscape option for quotes rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ module.exports = {
 		'no-unreachable': 2,
 		'valid-typeof': 2,
 		'quote-props': [ 2, 'as-needed' ],
-		quotes: ['error', 'single'],
+		quotes: ['error', 'single', { avoidEscape: true }],
 		'prefer-arrow-callback': 2,
 		'prefer-const': [ 2, { destructuring: all } ],
 		'arrow-spacing': 2,


### PR DESCRIPTION
The current configuration would enforce something like `'this is a \'quoted\' string'`

This rule change would allow double quotes to avoid quote escaping such as `"this is a 'quoted' string"`