### PR TITLE
turn off "import/no-unresolved"

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ module.exports = {
 		'comma-dangle': [ error, never ],
 		curly: [ error, 'multi-line' ],
 		'eol-last': error,
+		'import/no-unresolved': off,
 		'keyword-spacing': [ 2, { before: true, after: true } ],
 		'no-unused-vars': off,
 		'no-mixed-spaces-and-tabs': [ 2, 'smart-tabs' ],


### PR DESCRIPTION
unnecessary, unresolved modules, most likely caught by typescript check

and this will cause us to "adding legacy cruft to modules"