### PR TITLE
[chrore] Standardize type declarations

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,6 +40,7 @@ module.exports = {
 		'@typescript-eslint/explicit-function-return-type': off,
 		'@typescript-eslint/explicit-member-accessibility': off,
 		'@typescript-eslint/explicit-module-boundary-types': off,
+		'@typescript-eslint/method-signature-style': [error, "method"],
 		'@typescript-eslint/naming-convention': off,
 		'@typescript-eslint/no-empty-function': off,
 		'@typescript-eslint/no-explicit-any': off,


### PR DESCRIPTION
Most projects currently using this config don't have a standart set of guidelines to be followed when it comes to type declarations. This usually results in serious fragmentation of styles within a single repo.

While some choices really come to style, others can affect the development experience, such as using types over interfaces or vice versa (microsoft/TypeScript#15300) or the style of declaring methods as shown bellow.

Here `handler` is semantically a property of the object that happens to hold a function:
![semantics of property style](https://user-images.githubusercontent.com/61994401/128941479-36e5a8f8-b365-45b0-be58-d66945b5ae73.png)

But here `handler` is semantically a method of the object, not just a regular field:
![semantics of method style](https://user-images.githubusercontent.com/61994401/128941501-6698abf1-05ae-4ce5-8cb1-229d2fc73268.png)


