### PR TITLE
remove eslint-plugin-node

### DIFF
--- a/.changeset/heavy-goats-flash.md
+++ b/.changeset/heavy-goats-flash.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/eslint-config": patch
+---
+
+remove eslint-plugin-node

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "@changesets/cli": "^2.26.1",
     "eslint": "^8.40.0",
     "eslint-config-prettier": "^8.8.0",
-    "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-svelte": "^2.28.0",
     "eslint-plugin-unicorn": "^47.0.0",
     "typescript": "^5.0.4"
@@ -35,7 +34,6 @@
     "@typescript-eslint/parser": ">= 5",
     "eslint": ">= 8",
     "eslint-config-prettier": ">= 8",
-    "eslint-plugin-node": ">= 11",
     "eslint-plugin-svelte": ">= 2",
     "eslint-plugin-unicorn": ">= 47",
     "typescript": ">= 4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,9 +23,6 @@ devDependencies:
   eslint-config-prettier:
     specifier: ^8.8.0
     version: 8.8.0(eslint@8.40.0)
-  eslint-plugin-node:
-    specifier: ^11.1.0
-    version: 11.1.0(eslint@8.40.0)
   eslint-plugin-svelte:
     specifier: ^2.28.0
     version: 2.28.0(eslint@8.40.0)
@@ -977,32 +974,6 @@ packages:
       eslint: 8.40.0
     dev: true
 
-  /eslint-plugin-es@3.0.1(eslint@8.40.0):
-    resolution: {integrity: sha512-GUmAsJaN4Fc7Gbtl8uOBlayo2DqhwWvEzykMHSCZHU3XdJ+NSzzZcVhXh3VxX5icqQ+oQdIEawXX8xkR3mIFmQ==}
-    engines: {node: '>=8.10.0'}
-    peerDependencies:
-      eslint: '>=4.19.1'
-    dependencies:
-      eslint: 8.40.0
-      eslint-utils: 2.1.0
-      regexpp: 3.2.0
-    dev: true
-
-  /eslint-plugin-node@11.1.0(eslint@8.40.0):
-    resolution: {integrity: sha512-oUwtPJ1W0SKD0Tr+wqu92c5xuCeQqB3hSCHasn/ZgjFdA9iDGNkNf2Zi9ztY7X+hNuMib23LNGRm6+uN+KLE3g==}
-    engines: {node: '>=8.10.0'}
-    peerDependencies:
-      eslint: '>=5.16.0'
-    dependencies:
-      eslint: 8.40.0
-      eslint-plugin-es: 3.0.1(eslint@8.40.0)
-      eslint-utils: 2.1.0
-      ignore: 5.2.4
-      minimatch: 3.1.2
-      resolve: 1.22.2
-      semver: 6.3.0
-    dev: true
-
   /eslint-plugin-svelte@2.28.0(eslint@8.40.0):
     resolution: {integrity: sha512-bXPXKnjq5uKoVAQtC2E0L1Vp+mmJ3nlC9jyz8zwfZ99pQROL2h7Hes01QdYil1vxgh6tLXl5YVpZ2wwyAbBz5g==}
     engines: {node: ^14.17.0 || >=16.0.0}
@@ -1067,18 +1038,6 @@ packages:
     dependencies:
       esrecurse: 4.3.0
       estraverse: 5.3.0
-    dev: true
-
-  /eslint-utils@2.1.0:
-    resolution: {integrity: sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==}
-    engines: {node: '>=6'}
-    dependencies:
-      eslint-visitor-keys: 1.3.0
-    dev: true
-
-  /eslint-visitor-keys@1.3.0:
-    resolution: {integrity: sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==}
-    engines: {node: '>=4'}
     dev: true
 
   /eslint-visitor-keys@3.4.1:
@@ -2197,11 +2156,6 @@ packages:
       functions-have-names: 1.2.3
     dev: true
 
-  /regexpp@3.2.0:
-    resolution: {integrity: sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==}
-    engines: {node: '>=8'}
-    dev: true
-
   /regjsparser@0.10.0:
     resolution: {integrity: sha512-qx+xQGZVsy55CH0a1hiVwHmqjLryfh7wQyF5HO07XJ9f7dQMY/gPQHhlyDkIzJKC+x2fUCpCcUODUUUFrm7SHA==}
     hasBin: true
@@ -2275,11 +2229,6 @@ packages:
 
   /semver@5.7.1:
     resolution: {integrity: sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==}
-    hasBin: true
-    dev: true
-
-  /semver@6.3.0:
-    resolution: {integrity: sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==}
     hasBin: true
     dev: true
 


### PR DESCRIPTION
`eslint-plugin-node` is unmaintained. We could switch to the new version `eslint-plugin-n`, but it doesn't really appear to add much that wouldn't be caught by TypeScript already. Removing it will speed up linting. Also, the plugin didn't even appear to be enabled anyway, so I don't think we'll be losing anything by removing it :laughing: 