### PR TITLE
fix: remove old config referring to eslint-plugin-import

### DIFF
--- a/.changeset/healthy-cooks-know.md
+++ b/.changeset/healthy-cooks-know.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/eslint-config": patch
+---
+
+fix: remove old config referring to eslint-plugin-import

--- a/index.js
+++ b/index.js
@@ -47,9 +47,6 @@ module.exports = {
 	},
 	extends: [
 		'eslint:recommended',
-		'plugin:import/errors',
-		'plugin:import/warnings',
-		'plugin:import/typescript',
 		'plugin:@typescript-eslint/recommended',
 		'plugin:svelte/recommended',
 		'prettier'


### PR DESCRIPTION
missed this in https://github.com/sveltejs/eslint-config/pull/25