### PR TITLE
package only minimally necessary files

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,10 @@
   "author": "Svelte",
   "license": "MIT",
   "homepage": "https://github.com/svelte/eslint-config#readme",
+  "files": [
+    "index.js",
+    "package.json"
+  ],
   "devDependencies": {
     "@svitejs/changesets-changelog-github-compact": "^1.1.0",
     "@typescript-eslint/eslint-plugin": "^5.59.6",


### PR DESCRIPTION
right now it's shipping the `node_modules`, which makes it larger than necessary...