### PR TITLE
fix: remove projectService from base config

### DIFF
--- a/.changeset/gentle-ghosts-grow.md
+++ b/.changeset/gentle-ghosts-grow.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/eslint-config": patch
+---
+
+fix: remove projectService from base config"

--- a/index.js
+++ b/index.js
@@ -23,18 +23,6 @@ export default [
 			}
 		}
 	},
-	// projectService is resource intensive, so only listing rules that require it here
-	{
-		languageOptions: {
-			parserOptions: {
-				projectService: true
-			}
-		},
-		rules: {
-			'@typescript-eslint/await-thenable': 'error',
-			'@typescript-eslint/require-await': 'error'
-		}
-	},
 	{
 		plugins: {
 			n: node, '@stylistic': stylistic


### PR DESCRIPTION
I'm guessing this isn't working because of https://github.com/sveltejs/eslint-plugin-svelte/issues/1084. It works when we include it in the SvelteKit config because we disable so much stuff there