### PR TITLE
fix: update homepage url in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "author": "Svelte",
   "license": "MIT",
-  "homepage": "https://github.com/svelte/eslint-config#readme",
+  "homepage": "https://github.com/sveltejs/eslint-config#readme",
   "files": [
     "index.js",
     "package.json"


### PR DESCRIPTION
leads to 404s where this is used to create links (npmjs page, renovate PRs etc)